### PR TITLE
Recalulate displaySize and scaleFactor before initial canvas sizing

### DIFF
--- a/script.js
+++ b/script.js
@@ -355,14 +355,20 @@ canvas.setZoom(scaleFactor);
 canvas.setWidth(displaySize);
 canvas.setHeight(displaySize);
 
+const resizeCanvasToWindow = () => {
+  let canvasContainer = document.querySelector(".canvas-container");
+  canvasContainer.style.width = "100%";
+  canvasContainer.style.height = "100%";
+  displaySize = canvasContainer.clientWidth
+  scaleFactor = displaySize / CANVASSIZE;
+  canvas.setZoom(scaleFactor);
+  canvas.setWidth(displaySize);
+  canvas.setHeight(displaySize);
+};
+
+resizeCanvasToWindow();
+
 window.addEventListener('resize', function() {
-	let canvasContainer = document.querySelector(".canvas-container");
-	canvasContainer.style.width = "100%";
-	canvasContainer.style.height = "100%";
-	displaySize = canvasContainer.clientWidth
-	scaleFactor = displaySize / CANVASSIZE;
-	canvas.setZoom(scaleFactor);
-	canvas.setWidth(displaySize);
-	canvas.setHeight(displaySize);
+  resizeCanvasToWindow();
 });
 


### PR DESCRIPTION
The display size needs to be recalculated before initial width and height are set. I've not investigated why this works. But just factored out the code from the window resize handler and call that instead of manually calling `setWidth()`, `setHeight()`, `setZoom()`